### PR TITLE
Fix CI build failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: java
 sudo: false
+
+before_script:
+  - 'export MAVEN_OPTS="-Djava.util.logging.config.file=logging.properties"
+
 script: mvn compile assembly:single && mvn clean test
 
 jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 sudo: false
 
 before_script:
-  - 'export MAVEN_OPTS="-Djava.util.logging.config.file=logging.properties"
+  - 'export MAVEN_OPTS="-Djava.util.logging.config.file=logging.properties"'
 
 script: mvn compile assembly:single && mvn clean test
 

--- a/logging.properties
+++ b/logging.properties
@@ -1,0 +1,1 @@
+.level= WARNING


### PR DESCRIPTION
CI(Travis) builds are failing as the log size is exceeding 4MB(bummer). So, we need to reduce the log level for CI builds.